### PR TITLE
Migrate to using kobocat as kpi django app

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@ Clone kpi repo in this directory
 1. Start postgres `docker compose up postgres` this ensures it has time to initialize
 1. Run Django database migrations `docker compose run -rm kpi scripts/migrate.sh`
 1. Make user `docker compose run --rm kpi ./manage.py createsuperuser`
-1. Edit `/etc/hosts` and add `127.0.0.1 kf.kobo.local kc.kobo.local ee.kobo.local`
-1. Run `npm i --force` in the kpi directory.
+1. Edit `/etc/hosts` and add `127.0.0.1 kf.kobo.local ee.kobo.local`
+1. Run `npm i` in the kpi directory.
 
 # Start
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Clone kpi repo in this directory
 
 1. Build `docker compose build --pull`
 1. Start postgres `docker compose up postgres` this ensures it has time to initialize
-1. Run Django database migrations `docker compose run -rm kpi scripts/migrate.sh`
+1. Run Django database migrations `docker compose run --rm kpi scripts/migrate.sh`
 1. Make user `docker compose run --rm kpi ./manage.py createsuperuser`
 1. Edit `/etc/hosts` and add `127.0.0.1 kf.kobo.local ee.kobo.local`
 1. Run `npm i` in the kpi directory.
@@ -34,7 +34,7 @@ Go to http://localhost:8025
 
 # Rebuild docker images
 
-If python packages in kpi or kobocat change, you can build like this
+If python packages in kpi change, you can build like this
 
 `docker compose build --pull`
 

--- a/README.md
+++ b/README.md
@@ -1,11 +1,10 @@
 # First run
 
-Clone kpi and kobocat repos in this directory
+Clone kpi repo in this directory
 
 1. Build `docker compose build --pull`
 1. Start postgres `docker compose up postgres` this ensures it has time to initialize
-1. Migrate kobocat `docker compose run --rm kobocat ./manage.py migrate`
-1. Migrate kpi `docker compose run --rm kpi ./manage.py migrate`
+1. Run Django database migrations `docker compose run -rm kpi scripts/migrate.sh`
 1. Make user `docker compose run --rm kpi ./manage.py createsuperuser`
 1. Edit `/etc/hosts` and add `127.0.0.1 kf.kobo.local kc.kobo.local ee.kobo.local`
 1. Run `npm i --force` in the kpi directory.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -48,25 +48,8 @@ services:
     image: redis
   mongo:
     image: mongo
-  kobocat:
-    build: ./kobocat
-    depends_on: *default-depends_on
-    environment:
-      <<: *default-environment
-      DATABASE_URL: postgis://postgres:postgres@postgres:5432/kobocat
-    volumes:
-      - ./kobocat:/srv/src/kobocat
-      - ./.vols/kobocat_media_uploads:/srv/src/kobocat/media
-    command: ./manage.py runserver 0.0.0.0:8001
-    ports:
-      - "8001:8001"
-    networks:
-      default:
-        aliases:
-          - kc.kobo.local
-
   kobocat_worker:
-    build: ./kobocat
+    build: ./kpi
     depends_on: *default-depends_on
     environment:
       <<: *default-environment
@@ -88,7 +71,7 @@ services:
     environment:
       <<: *default-environment
       DATABASE_URL: postgres://postgres:postgres@postgres:5432/postgres
-      KC_DATABASE_URL: postgres://postgres:postgres@postgres:5432/kobocat
+      KC_DATABASE_URL: postgis://postgres:postgres@postgres:5432/kobocat
     volumes:
       - ./kpi:/srv/src/kpi
       - ./.vols/kobocat_media_uploads:/srv/src/kobocat/media
@@ -101,7 +84,7 @@ services:
     environment:
       <<: *default-environment
       DATABASE_URL: postgres://postgres:postgres@postgres:5432/postgres
-      KC_DATABASE_URL: postgres://postgres:postgres@postgres:5432/kobocat
+      KC_DATABASE_URL: postgis://postgres:postgres@postgres:5432/kobocat
     volumes:
       - ./kpi:/srv/src/kpi
     command: celery -A kobo worker -l info -B -s /tmp/celerybeat-schedule --autoscale=1,1

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ x-environment: &default-environment
   DJANGO_DEBUG: "true"
   PYTHONUNBUFFERED: 1
 
-  DATABASE_URL: postgres://postgres:postgres@postgres:5432/postgres
+  DATABASE_URL: postgis://postgres:postgres@postgres:5432/postgres
   KC_DATABASE_URL: postgis://postgres:postgres@postgres:5432/kobocat
 
   REDIS_SESSION_URL: redis://redis:6379/0

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,16 +3,18 @@ x-environment: &default-environment
   DJANGO_DEBUG: "true"
   PYTHONUNBUFFERED: 1
 
+  DATABASE_URL: postgres://postgres:postgres@postgres:5432/postgres
+  KC_DATABASE_URL: postgis://postgres:postgres@postgres:5432/kobocat
+
   REDIS_SESSION_URL: redis://redis:6379/0
   ENKETO_REDIS_MAIN_URL: redis://redis:6379/0
-  KPI_BROKER_URL: redis://redis:6379/2
-  KOBOCAT_BROKER_URL: redis://redis:6379/1
-  CACHE_URL: redis://redis:6379/3
-  SERVICE_ACCOUNT_BACKEND_URL: redis://redis:6379/4
+  CELERY_BROKER_URL: redis://redis:6379/1
+  CACHE_URL: redis://redis:6379/2
+  SERVICE_ACCOUNT_BACKEND_URL: redis://redis:6379/3
   
   PUBLIC_REQUEST_SCHEME: http
-  KOBOCAT_INTERNAL_URL: http://kobocat:8001
-  KOBOCAT_URL: http://kc.kobo.local:8001
+  KOBOCAT_INTERNAL_URL: http://kpi:8080
+  KOBOCAT_URL: http://kf.kobo.local:8080
   MONGO_DB_URL: mongodb://mongo:27017
   KOBOFORM_INTERNAL_URL: http://kpi:8080
   KOBOFORM_URL: http://kf.kobo.local:8080
@@ -48,15 +50,6 @@ services:
     image: redis
   mongo:
     image: mongo
-  kobocat_worker:
-    build: ./kpi
-    depends_on: *default-depends_on
-    environment:
-      <<: *default-environment
-      DATABASE_URL: postgis://postgres:postgres@postgres:5432/kobocat
-    volumes:
-      - ./kobocat:/srv/src/kobocat
-    command: celery -A onadata worker -l info -Ofair -B -s /tmp/celerybeat-schedule
   nginx:
     image: nginx
     volumes:
@@ -70,21 +63,21 @@ services:
     depends_on: *default-depends_on
     environment:
       <<: *default-environment
-      DATABASE_URL: postgres://postgres:postgres@postgres:5432/postgres
-      KC_DATABASE_URL: postgis://postgres:postgres@postgres:5432/kobocat
     volumes:
       - ./kpi:/srv/src/kpi
       - ./.vols/kobocat_media_uploads:/srv/src/kobocat/media
     command: ./manage.py runserver 0.0.0.0:8080
     ports:
       - "8080:8080"
+    networks:
+      default:
+        aliases:
+          - kf.kobo.local
   kpi_worker:
     build: ./kpi
     depends_on: *default-depends_on
     environment:
       <<: *default-environment
-      DATABASE_URL: postgres://postgres:postgres@postgres:5432/postgres
-      KC_DATABASE_URL: postgis://postgres:postgres@postgres:5432/kobocat
     volumes:
       - ./kpi:/srv/src/kpi
     command: celery -A kobo worker -l info -B -s /tmp/celerybeat-schedule --autoscale=1,1
@@ -100,7 +93,7 @@ services:
       ENKETO_REDIS_MAIN_URL: "redis://redis:6379"
       ENKETO_REDIS_CACHE_URL: "redis://redis:6379"
       ENKETO_MAX_PROCESSES: 1
-      ENKETO_LINKED_FORM_AND_DATA_SERVER_SERVER_URL: kc.kobo.local:8001
+      ENKETO_LINKED_FORM_AND_DATA_SERVER_SERVER_URL: kf.kobo.local:8080
       ENKETO_LINKED_FORM_AND_DATA_SERVER_AUTHENTICATION_ALLOW_INSECURE_TRANSPORT: "true"
     command: node app.js
     #command: node_modules/.bin/grunt develop


### PR DESCRIPTION
- Update kpi kobocat database postgis engine
- Remove kobocat  and kobocat worker services
- Migrate via scripts/migrate.sh
- Update environment variables


Questions for reviewer

1. Does it make the most sense to remove any trace of kc.kobo.local? We on longer appear to need it. No one is using kobo-compose for legacy kobocat support.
2. Does anything stand out to you as - Ok but don't do it this way in the helm chart