### PR TITLE
fix: read from all celery queues

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -82,7 +82,7 @@ services:
       <<: *default-environment
     volumes:
       - ./kpi:/srv/src/kpi
-    command: celery -A kobo worker -l info -B -s /tmp/celerybeat-schedule --autoscale=1,1
+    command: celery -A kobo worker -l info -B -s /tmp/celerybeat-schedule --autoscale=1,1 -Q kpi_low_priority_queue,kpi_queue,kobocat_queue
   enketo_express:
     image: kobotoolbox/enketo-express-extra-widgets:6.0.0
     init: true


### PR DESCRIPTION
Update the kpi_worker to read from all celery queues, not just the default.